### PR TITLE
chore: update detect circular reference docs

### DIFF
--- a/docs/rules/detect-circular-reference.md
+++ b/docs/rules/detect-circular-reference.md
@@ -4,8 +4,6 @@ description: 'Detects usage of `forwardRef()` function commonly used to handle c
 
 [Forward references](https://docs.nestjs.com/fundamentals/circular-dependency#forward-reference) are commonly used to handle circular dependencies between services or modules. For example, if `FooService` and `BarService` depend on each other, you can use `forwardRef()` to resolve the circular dependency. However, `forwardRef()` must be a last resort, and we generally recommend changing your code to avoid circular dependencies. This rule detects usage of the `forwardRef()` method so you can keep track of what potentially needs refactoring.
 
-One strategy to avoid circular dependencies between services is to make each responsible for a single use case. That way you decrease the interface and likelihood of circular dependencies. You can also avoid using services as facades for data repositories. Instead, services should be usually used to encapsulate business logic (commands). Leave query responsibilities to repositories.
-
 ## Options
 
 This rule has no additional options yet.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import enforceCloseTestingModuleRule from './rules/enforce-close-testing-module.rule';
 import checkInjectDecoratorRule from './rules/check-inject-decorator.rule';
+import detectCircularReferenceRule from './rules/detect-circular-reference.rule';
 // TODO: we should type this as ESLint.Plugin but there's a type incompatibilities with the utils package
 const plugin = {
   configs: {
@@ -7,12 +8,14 @@ const plugin = {
       rules: {
         '@trilon/enforce-close-testing-module': 'error',
         '@trilon/check-inject-decorator': 'error',
+        '@trilon/detect-circular-reference': 'warn',
       },
     },
   },
   rules: {
     'enforce-close-testing-module': enforceCloseTestingModuleRule,
     'check-inject-decorator': checkInjectDecoratorRule,
+    'detect-circular-reference': detectCircularReferenceRule,
   },
 };
 


### PR DESCRIPTION
Removes the suggestion for handling circular reference from docs as that is an extensive topic better covered by a blog post. Also adds the new rule to the "recommended" set.