### PR TITLE
fix: remove yarn engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.*.*",
-    "yarn": ">=4.0.2"
+    "node": ">=18.*.*"
   },
   "scripts": {
     "prepare": "tsc",
@@ -51,3 +50,4 @@
     "eslint": ">=8.0.0"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.*.*"
+    "node": ">=16.*.*"
   },
   "scripts": {
     "prepare": "tsc",
@@ -50,4 +50,3 @@
     "eslint": ">=8.0.0"
   }
 }
-


### PR DESCRIPTION
It should work with all versions of Yarn, this prevents users of classic Yarn from consuming the package.